### PR TITLE
Add support for Promise arguments

### DIFF
--- a/src/asyncp.js
+++ b/src/asyncp.js
@@ -55,6 +55,7 @@ import mapValuesLimit from './mapValuesLimit';
 import mapValuesSeries from './mapValuesSeries';
 import parallel from './parallel';
 import parallelLimit from './parallelLimit';
+import promised from './promised';
 import reduce from './reduce';
 import reduceRight from './reduceRight';
 import reject from './reject';
@@ -139,6 +140,7 @@ export default {
     mapValuesSeries,
     parallel,
     parallelLimit,
+    promised,
     reduce,
     reduceRight,
     reject,

--- a/src/concat.js
+++ b/src/concat.js
@@ -1,6 +1,7 @@
 import tryFn from './tryFn';
+import promised from './promised';
 
-export default function concat(collection, iteratee) {
+export default promised(function concat(collection, iteratee) {
     return Promise.all(collection.map((...args) => tryFn(iteratee, ...args)))
         .then((results) => results.reduce((result, item) => result.concat(item), []));
-};
+});

--- a/src/concatSeries.js
+++ b/src/concatSeries.js
@@ -1,6 +1,7 @@
 import tryFn from './tryFn';
+import promised from './promised';
 
-export default function concatSeries(collection, iteratee) {
+export default promised(function concatSeries(collection, iteratee) {
     return collection.reduce(
         (promise, item, index, collection) => promise.then((results) => {
             return tryFn(iteratee, item, index, collection)
@@ -8,4 +9,4 @@ export default function concatSeries(collection, iteratee) {
         }),
         Promise.resolve([])
     );
-};
+});

--- a/src/detect.js
+++ b/src/detect.js
@@ -1,7 +1,8 @@
 import tryFn from './tryFn';
+import promised from './promised';
 import PromiseBreak from './promiseBreak';
 
-export default function detect(collection, predicate, notFound = undefined) {
+export default promised(function detect(collection, predicate, notFound = undefined) {
     return Promise.all(collection.map((item, index, collection) => {
         return tryFn(predicate, item, index, collection)
             .then((result) => {
@@ -18,4 +19,4 @@ export default function detect(collection, predicate, notFound = undefined) {
             }
             throw error;
         });
-};
+});

--- a/src/detectLimit.js
+++ b/src/detectLimit.js
@@ -1,12 +1,13 @@
 import throat from 'throat';
 import tryFn from './tryFn';
+import promised from './promised';
 import PromiseBreak from './promiseBreak';
 
-export default function detectLimit(collection, limit, predicate, notFound = undefined) {
+export default promised(function detectLimit(collection, limit, predicate, notFound = undefined) {
     if (! limit > 0) {
         return Promise.reject(new Error('Limit must be a number greater than 0.'));
     }
-    
+
     return Promise.all(collection.map(throat(limit, (item, index, collection) => {
         return tryFn(predicate, item, index, collection)
             .then((result) => {
@@ -23,4 +24,4 @@ export default function detectLimit(collection, limit, predicate, notFound = und
             }
             throw error;
         });
-};
+});

--- a/src/detectSeries.js
+++ b/src/detectSeries.js
@@ -1,7 +1,8 @@
 import tryFn from './tryFn';
+import promised from './promised';
 import PromiseBreak from './promiseBreak';
 
-export default function detectSeries(collection, predicate, notFound = undefined) {
+export default promised(function detectSeries(collection, predicate, notFound = undefined) {
     return collection.reduce(
         (promise, item, index, collection) => {
             return promise.then(() => {
@@ -23,4 +24,4 @@ export default function detectSeries(collection, predicate, notFound = undefined
             }
             throw error;
         });
-};
+});

--- a/src/doUntil.js
+++ b/src/doUntil.js
@@ -1,11 +1,12 @@
 import tryFn from './tryFn';
+import promised from './promised';
 import until from './until';
 
-export default function doUntil(task, condition, ...args) {
+export default promised(function doUntil(task, condition, ...args) {
     return tryFn(task, ...args)
         .then((result) =>
             Array.isArray(result)
                 ? until(condition, task, ...result)
                 : until(condition, task, result)
         );
-};
+});

--- a/src/doWhilst.js
+++ b/src/doWhilst.js
@@ -1,11 +1,12 @@
 import tryFn from './tryFn';
+import promised from './promised';
 import whilst from './whilst';
 
-export default function doWhilst(task, condition, ...args) {
+export default promised(function doWhilst(task, condition, ...args) {
     return tryFn(task, ...args)
         .then((result) =>
             Array.isArray(result)
                 ? whilst(condition, task, ...result)
                 : whilst(condition, task, result)
         );
-};
+});

--- a/src/each.js
+++ b/src/each.js
@@ -1,5 +1,6 @@
 import tryFn from './tryFn';
+import promised from './promised';
 
-export default function each(collection, iteratee) {
+export default promised(function each(collection, iteratee) {
     return Promise.all(collection.map((...args) => tryFn(iteratee, ...args)));
-};
+});

--- a/src/eachLimit.js
+++ b/src/eachLimit.js
@@ -1,9 +1,10 @@
 import throat from 'throat';
+import promised from './promised';
 
-export default function eachLimit(collection, limit, iteratee) {
+export default promised(function eachLimit(collection, limit, iteratee) {
     if (! limit > 0) {
         return Promise.reject(new Error('Limit must be a number greater than 0.'));
     }
 
     return Promise.all(collection.map(throat(limit, iteratee)));
-};
+});

--- a/src/eachOf.js
+++ b/src/eachOf.js
@@ -1,6 +1,7 @@
 import tryFn from './tryFn';
+import promised from './promised';
 
-export default function eachOf(collection, iteratee) {
+export default promised(function eachOf(collection, iteratee) {
     const keys = Object.keys(collection);
     return Promise.all(
         keys.map((key) => tryFn(iteratee, collection[key], key, collection))
@@ -12,4 +13,4 @@ export default function eachOf(collection, iteratee) {
             },
             {}
         ));
-};
+});

--- a/src/eachOfLimit.js
+++ b/src/eachOfLimit.js
@@ -1,11 +1,12 @@
 import throat from 'throat';
 import tryFn from './tryFn';
+import promised from './promised';
 
-export default function eachOfLimit(collection, limit, iteratee) {
+export default promised(function eachOfLimit(collection, limit, iteratee) {
     if (! limit > 0) {
         return Promise.reject(new Error('Limit must be a number greater than 0.'));
     }
-        
+
     const keys = Object.keys(collection);
     const values = keys.map(key => collection[key]);
     return Promise.all(
@@ -20,4 +21,4 @@ export default function eachOfLimit(collection, limit, iteratee) {
             },
             {}
         ));
-};
+});

--- a/src/eachOfSeries.js
+++ b/src/eachOfSeries.js
@@ -1,6 +1,7 @@
 import tryFn from './tryFn';
+import promised from './promised';
 
-export default function eachOfSeries(collection, iteratee) {
+export default promised(function eachOfSeries(collection, iteratee) {
     return Object.keys(collection).reduce(
         (promise, key) => {
             let collectionValue = collection[key];
@@ -14,4 +15,4 @@ export default function eachOfSeries(collection, iteratee) {
         },
         Promise.resolve({})
     );
-};
+});

--- a/src/eachSeries.js
+++ b/src/eachSeries.js
@@ -1,6 +1,7 @@
 import tryFn from './tryFn';
+import promised from './promised';
 
-export default function eachSeries(collection, iteratee) {
+export default promised(function eachSeries(collection, iteratee) {
     return collection.reduce(
         (promise, ...args) => {
             return promise.then((results) => {
@@ -13,4 +14,4 @@ export default function eachSeries(collection, iteratee) {
         },
         Promise.resolve([])
     );
-};
+});

--- a/src/every.js
+++ b/src/every.js
@@ -1,7 +1,8 @@
 import tryFn from './tryFn';
+import promised from './promised';
 import PromiseBreak from './promiseBreak';
 
-export default function every(collection, predicate) {
+export default promised(function every(collection, predicate) {
     return Promise.all(collection.map((...args) => {
         return tryFn(predicate, ...args)
             .then((result) => {
@@ -18,4 +19,4 @@ export default function every(collection, predicate) {
             }
             throw error;
         });
-};
+});

--- a/src/everyLimit.js
+++ b/src/everyLimit.js
@@ -1,12 +1,13 @@
 import throat from 'throat';
 import tryFn from './tryFn';
+import promised from './promised';
 import PromiseBreak from './promiseBreak';
 
-export default function everyLimit(collection, limit, predicate) {
+export default promised(function everyLimit(collection, limit, predicate) {
     if (! limit > 0) {
         return Promise.reject(new Error('Limit must be a number greater than 0.'));
     }
-    
+
     return Promise.all(collection.map(throat(limit, (item, index, collection) => {
         return tryFn(predicate, item, index, collection)
             .then((result) => {
@@ -23,4 +24,4 @@ export default function everyLimit(collection, limit, predicate) {
             }
             throw error;
         });
-};
+});

--- a/src/everySeries.js
+++ b/src/everySeries.js
@@ -1,7 +1,8 @@
 import tryFn from './tryFn';
+import promised from './promised';
 import PromiseBreak from './promiseBreak';
 
-export default function everySeries(collection, predicate) {
+export default promised(function everySeries(collection, predicate) {
     return collection.reduce(
         (promise, ...args) => {
             return promise.then(() => {
@@ -23,4 +24,4 @@ export default function everySeries(collection, predicate) {
             }
             throw error;
         });
-};
+});

--- a/src/filter.js
+++ b/src/filter.js
@@ -1,8 +1,9 @@
 import tryFn from './tryFn';
+import promised from './promised';
 
 const ASYNCP_UNDEFINED = '__ASYNCP_UNDEFINED__';
 
-export default function filter(collection, predicate) {
+export default promised(function filter(collection, predicate) {
     return Promise.all(
         collection.map((item, index, collection) =>
             tryFn(predicate, item, index, collection)
@@ -10,4 +11,4 @@ export default function filter(collection, predicate) {
         )
     )
         .then(results => results.filter(item => item != ASYNCP_UNDEFINED));
-};
+});

--- a/src/filterLimit.js
+++ b/src/filterLimit.js
@@ -1,9 +1,10 @@
 import throat from 'throat';
 import tryFn from './tryFn';
+import promised from './promised';
 
 const ASYNCP_UNDEFINED = '__ASYNCP_UNDEFINED__';
 
-export default function filterLimit(collection, limit, predicate) {
+export default promised(function filterLimit(collection, limit, predicate) {
     if (! limit > 0) {
         return Promise.reject(new Error('Limit must be a number greater than 0.'));
     }
@@ -13,4 +14,4 @@ export default function filterLimit(collection, limit, predicate) {
             .then(result => result === true ? item : ASYNCP_UNDEFINED)
     )))
         .then(results => results.filter(item => item != ASYNCP_UNDEFINED));
-};
+});

--- a/src/filterSeries.js
+++ b/src/filterSeries.js
@@ -1,6 +1,7 @@
 import tryFn from './tryFn';
+import promised from './promised';
 
-export default function filterSeries(collection, predicate) {
+export default promised(function filterSeries(collection, predicate) {
     return collection.reduce(
         (promise, item, index, collection) => {
             return promise.then((results) => {
@@ -15,4 +16,4 @@ export default function filterSeries(collection, predicate) {
         },
         Promise.resolve([])
     );
-};
+});

--- a/src/forever.js
+++ b/src/forever.js
@@ -1,9 +1,10 @@
 import tryFn from './tryFn';
+import promised from './promised';
 
-export default function forever(task, ...args) {
+export default promised(function forever(task, ...args) {
     return tryFn(task, ...args).then((result) =>
         Array.isArray(result)
             ? forever(task, ...result)
             : forever(task, result)
     );
-};
+});

--- a/src/parallel.js
+++ b/src/parallel.js
@@ -1,5 +1,6 @@
 import tryFn from './tryFn';
+import promised from './promised';
 
-export default function parallel(tasks, ...args) {
+export default promised(function parallel(tasks, ...args) {
     return Promise.all(tasks.map((task) => tryFn(task, ...args)));
-};
+});

--- a/src/parallelLimit.js
+++ b/src/parallelLimit.js
@@ -1,10 +1,11 @@
 import throat from 'throat';
 import tryFn from './tryFn';
+import promised from './promised';
 
-export default function parallelLimit(tasks, limit, ...args) {
+export default promised(function parallelLimit(tasks, limit, ...args) {
     if (! limit > 0) {
         return Promise.reject(new Error('Limit must be a number greater than 0.'));
     }
 
     return Promise.all(tasks.map(throat(limit, (task) => tryFn(task, ...args))));
-};
+});

--- a/src/promised.js
+++ b/src/promised.js
@@ -1,0 +1,6 @@
+export default function promised(fn) {
+    return function(...args) {
+        return Promise.all(args)
+            .then(args => fn.call(this, ...args));
+    }
+};

--- a/src/reduce.js
+++ b/src/reduce.js
@@ -1,10 +1,11 @@
 import tryFn from './tryFn';
+import promised from './promised';
 
-export default function reduce(collection, result, iteratee) {
+export default promised(function reduce(collection, result, iteratee) {
     return collection.reduce(
         (promise, item, index, collection) => {
             return promise.then((result) => tryFn(iteratee, result, item, index, collection));
         },
         Promise.resolve(result)
     );
-};
+});

--- a/src/reduceRight.js
+++ b/src/reduceRight.js
@@ -1,10 +1,11 @@
 import tryFn from './tryFn';
+import promised from './promised';
 
-export default function reduceRight(collection, result, iteratee) {
+export default promised(function reduceRight(collection, result, iteratee) {
     return collection.reduceRight(
         (promise, item, index, collection) => {
             return promise.then((result) => tryFn(iteratee, result, item, index, collection));
         },
         Promise.resolve(result)
     );
-};
+});

--- a/src/reject.js
+++ b/src/reject.js
@@ -1,8 +1,9 @@
 import tryFn from './tryFn';
+import promised from './promised';
 
 const ASYNCP_UNDEFINED = '__ASYNCP_UNDEFINED__';
 
-export default function reject(collection, predicate) {
+export default promised(function reject(collection, predicate) {
     return Promise.all(
         collection.map((item, index, collection) =>
             tryFn(predicate, item, index, collection)
@@ -10,4 +11,4 @@ export default function reject(collection, predicate) {
         )
     )
         .then(results => results.filter(item => item != ASYNCP_UNDEFINED));
-};
+});

--- a/src/rejectLimit.js
+++ b/src/rejectLimit.js
@@ -1,9 +1,10 @@
 import throat from 'throat';
 import tryFn from './tryFn';
+import promised from './promised';
 
 const ASYNCP_UNDEFINED = '__ASYNCP_UNDEFINED__';
 
-export default function rejectLimit(collection, limit, predicate) {
+export default promised(function rejectLimit(collection, limit, predicate) {
     if (! limit > 0) {
         return Promise.reject(new Error('Limit must be a number greater than 0.'));
     }
@@ -13,4 +14,4 @@ export default function rejectLimit(collection, limit, predicate) {
             .then(result => result === true ? ASYNCP_UNDEFINED : item)
     )))
         .then(results => results.filter(item => item != ASYNCP_UNDEFINED));
-};
+});

--- a/src/rejectSeries.js
+++ b/src/rejectSeries.js
@@ -1,6 +1,7 @@
 import tryFn from './tryFn';
+import promised from './promised';
 
-export default function rejectSeries(collection, predicate) {
+export default promised(function rejectSeries(collection, predicate) {
     return collection.reduce(
         (promise, item, index, collection) => {
             return promise.then((results) => {
@@ -15,4 +16,4 @@ export default function rejectSeries(collection, predicate) {
         },
         Promise.resolve([])
     );
-};
+});

--- a/src/retry.js
+++ b/src/retry.js
@@ -1,8 +1,9 @@
 import isPlainObject from './isPlainObject';
 import tryFn from './tryFn';
+import promised from './promised';
 import PromiseBreak from './promiseBreak';
 
-export default function retry(opts, ...args) {
+export default promised(function retry(opts, ...args) {
     let task;
 
     if (typeof opts == 'function') {
@@ -71,4 +72,4 @@ export default function retry(opts, ...args) {
                 }
                 throw error;
             });
-};
+});

--- a/src/series.js
+++ b/src/series.js
@@ -1,6 +1,7 @@
 import tryFn from './tryFn'
+import promised from './promised';
 
-export default function series(tasks, ...args) {
+export default promised(function series(tasks, ...args) {
     if (!Array.isArray(tasks)) {
         return Promise.reject(new Error('First argument to series must be an array of functions'))
     }
@@ -15,4 +16,4 @@ export default function series(tasks, ...args) {
         }),
         Promise.resolve([])
     );
-};
+});

--- a/src/some.js
+++ b/src/some.js
@@ -1,8 +1,9 @@
 import detect from './detect';
+import promised from './promised';
 
 const NOT_FOUND = '__ASYNCP_NOT_FOUND__';
 
-export default function some(collection, predicate) {
+export default promised(function some(collection, predicate) {
     return detect(collection, predicate, NOT_FOUND)
         .then((result) => result !== NOT_FOUND);
-};
+});

--- a/src/someLimit.js
+++ b/src/someLimit.js
@@ -1,8 +1,9 @@
 import detectLimit from './detectLimit';
+import promised from './promised';
 
 const NOT_FOUND = '__ASYNCP_NOT_FOUND__'
 
-export default function someLimit(collection, limit, predicate) {
+export default promised(function someLimit(collection, limit, predicate) {
     return detectLimit(collection, limit, predicate, NOT_FOUND)
         .then((result) => result !== NOT_FOUND);
-};
+});

--- a/src/someSeries.js
+++ b/src/someSeries.js
@@ -1,8 +1,9 @@
 import detectSeries from './detectSeries';
+import promised from './promised';
 
 const NOT_FOUND = '__ASYNCP_NOT_FOUND__'
 
-export default function someSeries(collection, predicate) {
+export default promised(function someSeries(collection, predicate) {
     return detectSeries(collection, predicate, NOT_FOUND)
         .then((result) => result !== NOT_FOUND);
-};
+});

--- a/src/sortBy.js
+++ b/src/sortBy.js
@@ -1,6 +1,7 @@
 import tryFn from './tryFn';
+import promised from './promised';
 
-export default function sortBy(collection, iteratee, comparator) {
+export default promised(function sortBy(collection, iteratee, comparator) {
     if (comparator == null) {
         comparator = (a, b) => a < b ? -1 : a > b ? 1 : 0;
     }
@@ -10,4 +11,4 @@ export default function sortBy(collection, iteratee, comparator) {
             .then((result) => [result, item])
     ))
         .then((results) => results.sort(([a], [b]) => comparator(a, b)).map(([_, item]) => item));
-};
+});

--- a/src/times.js
+++ b/src/times.js
@@ -1,9 +1,10 @@
 import tryFn from './tryFn';
+import promised from './promised';
 
-export default function times(n, iteratee, ...args) {
+export default promised(function times(n, iteratee, ...args) {
     return Promise.all(
         new Array(n)
             .fill()
             .map((item, index) => tryFn(iteratee, index, ...args))
     );
-};
+});

--- a/src/timesLimit.js
+++ b/src/timesLimit.js
@@ -1,10 +1,11 @@
 import throat from 'throat';
 import tryFn from './tryFn';
+import promised from './promised';
 
-export default function timesLimit(n, limit, iteratee, ...args) {
+export default promised(function timesLimit(n, limit, iteratee, ...args) {
     return Promise.all(
         new Array(n)
             .fill()
             .map(throat(limit, (item, index) => tryFn(iteratee, index, ...args)))
     );
-};
+});

--- a/src/timesSeries.js
+++ b/src/timesSeries.js
@@ -1,6 +1,7 @@
 import tryFn from './tryFn';
+import promised from './promised';
 
-export default function timesSeries(n, iteratee, ...args) {
+export default promised(function timesSeries(n, iteratee, ...args) {
     return new Array(n).fill()
         .reduce(
             (promise, item, index) => {
@@ -14,4 +15,4 @@ export default function timesSeries(n, iteratee, ...args) {
             },
             Promise.resolve([])
         );
-};
+});

--- a/src/transform.js
+++ b/src/transform.js
@@ -1,6 +1,7 @@
 import tryFn from './tryFn';
+import promised from './promised';
 
-export default function transform(collection, accumulator, iteratee) {
+export default promised(function transform(collection, accumulator, iteratee) {
     if (arguments.length === 2) {
         iteratee = accumulator;
         accumulator = Array.isArray(collection) ? [] : {}
@@ -11,4 +12,4 @@ export default function transform(collection, accumulator, iteratee) {
         Promise.resolve()
     )
         .then(_ => accumulator);
-};
+});

--- a/src/until.js
+++ b/src/until.js
@@ -1,6 +1,7 @@
 import tryFn from './tryFn';
+import promised from './promised';
 
-export default function until(condition, task, ...args) {
+export default promised(function until(condition, task, ...args) {
     return tryFn(condition, ...args)
         .then((conditionResult) => {
             return conditionResult
@@ -11,4 +12,4 @@ export default function until(condition, task, ...args) {
                         : until(condition, task, result)
                 );
         });
-};
+});

--- a/src/waterfall.js
+++ b/src/waterfall.js
@@ -1,7 +1,8 @@
 import tryFn from './tryFn';
+import promised from './promised';
 import WaterfallError from './waterfallError';
 
-export default function waterfall(tasks, ...args) {
+export default promised(function waterfall(tasks, ...args) {
     if (!Array.isArray(tasks)) {
         return Promise.reject(new Error('First argument to waterfall must be an array of functions'))
     }
@@ -27,4 +28,4 @@ export default function waterfall(tasks, ...args) {
         .catch((error) => {
             throw new WaterfallError(error.message, results);
         });
-};
+});

--- a/src/whilst.js
+++ b/src/whilst.js
@@ -1,6 +1,7 @@
 import tryFn from './tryFn';
+import promised from './promised';
 
-export default function whilst(condition, task, ...args) {
+export default promised(function whilst(condition, task, ...args) {
     return tryFn(condition, ...args)
         .then((conditionResult) => {
             return conditionResult
@@ -12,4 +13,4 @@ export default function whilst(condition, task, ...args) {
                     )
                 : Promise.resolve();
         });
-};
+});

--- a/test/concat.js
+++ b/test/concat.js
@@ -106,6 +106,19 @@ describe('concat', function() {
         });
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const arr = [1, 3, 2];
+        const p = async.concat(
+            new Promise(resolve => setTimeout(resolve.bind(null, arr), 25)),
+            iterateeDelayWithOrder(order, x => [x, x + 1])
+        );
+        return Promise.all([
+            p.should.eventually.deep.equal([1, 2, 3, 4, 2, 3]),
+            p.then(() => order.should.deep.equal([1, 2, 3]))
+        ]);
+    });
+
     it('supports empty collections', function() {
         const p = async.concat([], () => assert(false, 'iteratee should not be called'));
 
@@ -149,9 +162,9 @@ describe('concat', function() {
         arr.shift();
 
         return Promise.all([
-            p.should.eventually.deep.equal([4, 5, 3, 4, 2, 3, 1, 2]),
+            p.should.eventually.deep.equal([3, 4, 2, 3]),
             p.then(() => arr.should.deep.equal([3, 2])),
-            p.then(() => order.should.deep.equal([4, 1, 2, 3]))
+            p.then(() => order.should.deep.equal([2, 3]))
         ]);
     });
 

--- a/test/concatSeries.js
+++ b/test/concatSeries.js
@@ -106,6 +106,19 @@ describe('concatSeries', function() {
         });
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const arr = [1, 3, 2];
+        const p = async.concatSeries(
+            new Promise(resolve => setTimeout(resolve.bind(null, arr), 25)),
+            iterateeDelayWithOrder(order, x => [x, x + 1])
+        );
+        return Promise.all([
+            p.should.eventually.deep.equal([1, 2, 3, 4, 2, 3]),
+            p.then(() => order.should.deep.equal(arr))
+        ]);
+    });
+
     it('supports empty collections', function() {
         const p = async.concatSeries([], () => assert(false, 'iteratee should not be called'));
 
@@ -149,9 +162,9 @@ describe('concatSeries', function() {
         arr.shift();
 
         return Promise.all([
-            p.should.eventually.deep.equal([4, 5, 3, 4, 2, 3, 1, 2]),
+            p.should.eventually.deep.equal([3, 4, 2, 3]),
             p.then(() => arr.should.deep.equal([3, 2])),
-            p.then(() => order.should.deep.equal([4, 3, 2, 1]))
+            p.then(() => order.should.deep.equal([3, 2]))
         ]);
     });
 

--- a/test/detect.js
+++ b/test/detect.js
@@ -123,6 +123,24 @@ describe('detect', function() {
         });
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const arr = [3, 2, 1];
+        const p = async.detect(
+            new Promise(resolve => setTimeout(resolve.bind(null, arr), 25)),
+            iterateeDelayWithOrder(order, (x) => x == 2)
+        );
+
+        return Promise.all([
+            p.should.eventually.equal(2),
+            new Promise(resolve => setTimeout(
+                () => resolve(order.should.deep.equal([1, 2, 3])),
+                5 * 25
+            ))
+        ]);
+    });
+
+
     it('supports not found', function() {
         const p = async.detect([1, 2, 3], () => false);
 
@@ -182,7 +200,7 @@ describe('detect', function() {
             p.should.eventually.equal(2),
             p.then(() => arr.should.deep.equal([3, 2])),
             new Promise(resolve => setTimeout(
-                () => resolve(order.should.deep.equal([4, 1, 2, 3])),
+                () => resolve(order.should.deep.equal([2, 3])),
                 5 * 25
             ))
         ]);

--- a/test/detectLimit.js
+++ b/test/detectLimit.js
@@ -123,6 +123,24 @@ describe('detectLimit', function() {
         });
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const arr = [3, 1, 2, 1, 2];
+        const p = async.detectLimit(
+            new Promise(resolve => setTimeout(resolve.bind(null, arr), 25)),
+            2,
+            iterateeDelayWithOrder(order, (x) => x == 2)
+        );
+
+        return Promise.all([
+            p.should.eventually.equal(2),
+            new Promise(resolve => setTimeout(
+                () => resolve(order.should.deep.equal([1, 3, 2, 1, 2])),
+                9 * 25
+            ))
+        ]);
+    });
+
     it('supports not found', function() {
         const p = async.detectLimit([1, 2, 3], 2, () => false);
 
@@ -210,7 +228,7 @@ describe('detectLimit', function() {
             p.should.eventually.equal(2),
             p.then(() => arr.should.deep.equal([3, 2])),
             new Promise(resolve => setTimeout(
-                () => resolve(order.should.deep.equal([4, 2, 1, 3])),
+                () => resolve(order.should.deep.equal([2, 3])),
                 7 * 25
             ))
         ]);

--- a/test/detectSeries.js
+++ b/test/detectSeries.js
@@ -123,6 +123,23 @@ describe('detectSeries', function() {
         });
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const arr = [3, 2, 1];
+        const p = async.detectSeries(
+            new Promise(resolve => setTimeout(resolve.bind(null, arr), 25)),
+            iterateeDelayWithOrder(order, (x) => x == 2)
+        );
+
+        return Promise.all([
+            p.should.eventually.equal(2),
+            new Promise(resolve => setTimeout(
+                () => resolve(order.should.deep.equal([3, 2])),
+                7 * 25
+            ))
+        ]);
+    });
+
     it('supports not found', function() {
         const p = async.detectSeries([1, 2, 3], () => false);
 
@@ -182,7 +199,7 @@ describe('detectSeries', function() {
             p.should.eventually.equal(2),
             p.then(() => arr.should.deep.equal([3, 2])),
             new Promise(resolve => setTimeout(
-                () => resolve(order.should.deep.equal([4, 3, 2])),
+                () => resolve(order.should.deep.equal([3, 2])),
                 11 * 25
             ))
         ]);

--- a/test/doUntil.js
+++ b/test/doUntil.js
@@ -103,6 +103,50 @@ describe('doUntil', function() {
         ]);
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const p = async.doUntil(
+            new Promise(resolve => setTimeout(
+                resolve.bind(
+                    null,
+                    count => new Promise(resolve => setTimeout(_ => {
+                        order.push(`task${count}`);
+                        count++;
+                        resolve(count);
+                    }, 25))
+                ),
+                25
+            )),
+            new Promise(resolve => setTimeout(
+                resolve.bind(
+                    null,
+                    count => new Promise(resolve => setTimeout(_ => {
+                        order.push(`condition${count}`);
+                        resolve(count == 5);
+                    }, 25))
+                ),
+                25
+            )),
+            Promise.resolve(0)
+        );
+
+        return Promise.all([
+            p.should.eventually.equal(undefined),
+            p.then(() => order.should.deep.equal([
+                'task0',
+                'condition1',
+                'task1',
+                'condition2',
+                'task2',
+                'condition3',
+                'task3',
+                'condition4',
+                'task4',
+                'condition5'
+            ]))
+        ]);
+    });
+
     it('rejects in delayed task', function() {
         let order = [];
         const p = async.doUntil(

--- a/test/doWhilst.js
+++ b/test/doWhilst.js
@@ -103,6 +103,54 @@ describe('doWhilst', function() {
         ]);
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const p = async.doWhilst(
+            new Promise(resolve => setTimeout(
+                resolve.bind(
+                    null,
+                    count => new Promise(resolve => setTimeout(_ => {
+                        order.push(`task${count}`);
+                        count++;
+                        resolve(count);
+                    }, 25))
+                ),
+                25
+            )),
+
+            new Promise(resolve => setTimeout(
+                resolve.bind(
+                    null,
+                    count => new Promise(resolve => setTimeout(_ => {
+                        order.push(`condition${count}`);
+                        resolve(count < 5);
+                    }, 25))
+                ),
+                25
+            )),
+
+
+            Promise.resolve(0)
+        );
+
+        return Promise.all([
+            p.should.eventually.equal(undefined),
+            p.then(() => order.should.deep.equal([
+                'task0',
+                'condition1',
+                'task1',
+                'condition2',
+                'task2',
+                'condition3',
+                'task3',
+                'condition4',
+                'task4',
+                'condition5'
+            ]))
+        ]);
+    });
+
+
     it('rejects in delayed task', function() {
         let order = [];
         const p = async.doWhilst(

--- a/test/each.js
+++ b/test/each.js
@@ -86,6 +86,19 @@ describe('each', function() {
         });
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const arr = [1, 3, 2];
+        const p = async.each(
+            new Promise(resolve => setTimeout(resolve.bind(null, arr), 25)),
+            iterateeDelayWithOrder(order)
+        );
+        return Promise.all([
+            p.should.eventually.deep.equal(arr),
+            p.then(() => order.should.deep.equal([1, 2, 3]))
+        ]);
+    });
+
     it('supports empty collections', function() {
         const p = async.each([], () => assert(false, 'iteratee should not be called'));
 
@@ -129,9 +142,9 @@ describe('each', function() {
         arr.shift();
 
         return Promise.all([
-            p.should.eventually.deep.equal([4, 3, 2, 1]),
+            p.should.eventually.deep.equal([3, 2]),
             p.then(() => arr.should.deep.equal([3, 2])),
-            p.then(() => order.should.deep.equal([4, 1, 2, 3]))
+            p.then(() => order.should.deep.equal([2, 3]))
         ]);
     });
 

--- a/test/eachLimit.js
+++ b/test/eachLimit.js
@@ -87,6 +87,21 @@ describe('eachLimit', function() {
         });
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const arr = [3, 1, 2, 1, 2];
+        const p = async.eachLimit(
+            new Promise(resolve => setTimeout(resolve.bind(null, arr), 25)),
+            2,
+            iterateeDelayWithOrder(order)
+        );
+
+        return Promise.all([
+            p.should.eventually.deep.equal(arr),
+            p.then(() => order.should.deep.equal([1, 3, 2, 1, 2]))
+        ]);
+    });
+
     it('supports empty collections', function() {
         const p = async.eachLimit([], 2, () => assert(false, 'iteratee should not be called'));
 
@@ -152,9 +167,9 @@ describe('eachLimit', function() {
         arr.shift();
 
         return Promise.all([
-            p.should.eventually.deep.equal([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+            p.should.eventually.deep.equal([1, 2, 3, 4, 5, 6, 7, 8]),
             p.then(() => arr.should.deep.equal([1, 2, 3, 4, 5, 6, 7, 8])),
-            p.then(() => order.should.deep.equal([0, 1, 2, 3, 4, 7, 8, 9, 5, 6]))
+            p.then(() => order.should.deep.equal([1, 2, 3, 4, 7, 8, 5, 6]))
         ]);
     });
 

--- a/test/eachOf.js
+++ b/test/eachOf.js
@@ -86,6 +86,20 @@ describe('eachOf', function() {
         });
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const coll = {a: 1, b: 3, c: 2};
+        const p = async.eachOf(
+            new Promise(resolve => setTimeout(resolve.bind(null, coll), 25)),
+            iterateeDelayWithOrder(order)
+        );
+        return Promise.all([
+            p.should.eventually.deep.equal(coll),
+            p.then(() => order.should.deep.equal([1, 2, 3]))
+        ]);
+    });
+
+
     it('supports empty collections', function() {
         const p = async.eachOf({}, () => assert(false, 'iteratee should not be called'));
 
@@ -118,9 +132,9 @@ describe('eachOf', function() {
         delete coll.d;
 
         return Promise.all([
-            p.should.eventually.deep.equal({a: 4, b: 3, c: 2, d: 1}),
+            p.should.eventually.deep.equal({a: 0, b: 3, c: 2}),
             p.then(() => coll.should.deep.equal({a: 0, b: 3, c: 2})),
-            p.then(() => order.should.deep.equal([4, 1, 2, 3]))
+            p.then(() => order.should.deep.equal([0, 2, 3]))
         ]);
     });
 

--- a/test/eachOfLimit.js
+++ b/test/eachOfLimit.js
@@ -86,6 +86,21 @@ describe('eachOfLimit', function() {
         });
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const coll = {a: 1, b: 4, c: 2};
+        const p = async.eachOfLimit(
+            new Promise(resolve => setTimeout(resolve.bind(null, coll), 25)),
+            2,
+            iterateeDelayWithOrder(order)
+        );
+        return Promise.all([
+            p.should.eventually.deep.equal(coll),
+            p.then(() => order.should.deep.equal([1, 2, 4]))
+        ]);
+    });
+
+
     it('supports empty collections', function() {
         const p = async.eachOfLimit({}, 2, () => assert(false, 'iteratee should not be called'));
 
@@ -140,9 +155,9 @@ describe('eachOfLimit', function() {
         delete coll.d;
 
         return Promise.all([
-            p.should.eventually.deep.equal({a: 4, b: 3, c: 2, d: 1}),
+            p.should.eventually.deep.equal({a: 0, b: 3, c: 2}),
             p.then(() => coll.should.deep.equal({a: 0, b: 3, c: 2})),
-            p.then(() => order.should.deep.equal([4, 2, 1, 3]))
+            p.then(() => order.should.deep.equal([0, 2, 3]))
         ]);
     });
 

--- a/test/eachOfSeries.js
+++ b/test/eachOfSeries.js
@@ -86,6 +86,20 @@ describe('eachOfSeries', function() {
         });
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const coll = {a: 1, b: 3, c: 2};
+        const p = async.eachOfSeries(
+            new Promise(resolve => setTimeout(resolve.bind(null, coll), 25)),
+            iterateeDelayWithOrder(order)
+        );
+        return Promise.all([
+            p.should.eventually.deep.equal(coll),
+            p.then(() => order.should.deep.equal([1, 3, 2]))
+        ]);
+    });
+
+
     it('supports empty collections', function() {
         const p = async.eachOfSeries({}, () => assert(false, 'iteratee should not be called'));
 
@@ -118,9 +132,9 @@ describe('eachOfSeries', function() {
         delete coll.d;
 
         return Promise.all([
-            p.should.eventually.deep.equal({a: 4, b: 3, c: 2, d: 1}),
+            p.should.eventually.deep.equal({a: 0, b: 3, c: 2}),
             p.then(() => coll.should.deep.equal({a: 0, b: 3, c: 2})),
-            p.then(() => order.should.deep.equal([4, 3, 2, 1]))
+            p.then(() => order.should.deep.equal([0, 3, 2]))
         ]);
     });
 

--- a/test/eachSeries.js
+++ b/test/eachSeries.js
@@ -87,6 +87,20 @@ describe('eachSeries', function() {
         });
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const arr = [1, 3, 2];
+        const p = async.eachSeries(
+            new Promise(resolve => setTimeout(resolve.bind(null, arr), 25)),
+            iterateeDelayWithOrder(order)
+        );
+        return Promise.all([
+            p.should.eventually.deep.equal(arr),
+            p.then(() => order.should.deep.equal(arr))
+        ]);
+    });
+
+
     it('supports empty collections', function() {
         const p = async.eachSeries([], () => assert(false, 'iteratee should not be called'));
 
@@ -130,9 +144,9 @@ describe('eachSeries', function() {
         arr.shift();
 
         return Promise.all([
-            p.should.eventually.deep.equal([4, 3, 2, 1]),
+            p.should.eventually.deep.equal([3, 2]),
             p.then(() => arr.should.deep.equal([3, 2])),
-            p.then(() => order.should.deep.equal([4, 3, 2, 1]))
+            p.then(() => order.should.deep.equal([3, 2]))
         ]);
     });
 

--- a/test/every.js
+++ b/test/every.js
@@ -101,6 +101,20 @@ describe('every', function() {
         });
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const arr = [3, 2, 1];
+        const p = async.every(
+            new Promise(resolve => setTimeout(resolve.bind(null, arr), 25)),
+            iterateeDelayWithOrder(order, (x) => x >= 1)
+        );
+
+        return Promise.all([
+            p.should.eventually.equal(true),
+            p.then(() => order.should.deep.equal([1, 2, 3]))
+        ]);
+    });
+
     it('supports empty collections', function() {
         const p = async.every([], () => assert(false, 'iteratee should not be called'));
 
@@ -136,7 +150,7 @@ describe('every', function() {
             p.should.eventually.equal(true),
             p.then(() => arr.should.deep.equal([3, 2])),
             new Promise(resolve => setTimeout(
-                () => resolve(order.should.deep.equal([4, 1, 2, 3])),
+                () => resolve(order.should.deep.equal([2, 3])),
                 5 * 25
             ))
         ]);

--- a/test/everyLimit.js
+++ b/test/everyLimit.js
@@ -101,6 +101,21 @@ describe('everyLimit', function() {
         });
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const arr = [3, 2, 1];
+        const p = async.everyLimit(
+            new Promise(resolve => setTimeout(resolve.bind(null, arr), 25)),
+            2,
+            iterateeDelayWithOrder(order, (x) => x >= 1)
+        );
+
+        return Promise.all([
+            p.should.eventually.equal(true),
+            p.then(() => order.should.deep.equal([2, 3, 1]))
+        ]);
+    });
+
     it('supports empty collections', function() {
         const p = async.everyLimit([], 2, () => assert(false, 'iteratee should not be called'));
 
@@ -164,7 +179,7 @@ describe('everyLimit', function() {
             p.should.eventually.equal(true),
             p.then(() => arr.should.deep.equal([3, 2])),
             new Promise(resolve => setTimeout(
-                () => resolve(order.should.deep.equal([4, 2, 1, 3])),
+                () => resolve(order.should.deep.equal([2, 3])),
                 5 * 25
             ))
         ]);

--- a/test/everySeries.js
+++ b/test/everySeries.js
@@ -101,6 +101,20 @@ describe('everySeries', function() {
         });
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const arr = [3, 2, 1];
+        const p = async.everySeries(
+            new Promise(resolve => setTimeout(resolve.bind(null, arr), 25)),
+            iterateeDelayWithOrder(order, (x) => x >= 1)
+        );
+
+        return Promise.all([
+            p.should.eventually.equal(true),
+            p.then(() => order.should.deep.equal(arr))
+        ]);
+    });
+
     it('supports empty collections', function() {
         const p = async.everySeries([], () => assert(false, 'iteratee should not be called'));
 
@@ -136,7 +150,7 @@ describe('everySeries', function() {
             p.should.eventually.equal(true),
             p.then(() => arr.should.deep.equal([3, 2])),
             new Promise(resolve => setTimeout(
-                () => resolve(order.should.deep.equal([4, 3, 2, 1])),
+                () => resolve(order.should.deep.equal([3, 2])),
                 6 * 25
             ))
         ]);

--- a/test/filter.js
+++ b/test/filter.js
@@ -130,6 +130,24 @@ describe('filter', function() {
         });
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const arr = [3, 2, 1];
+        const p = async.filter(
+            new Promise(resolve => setTimeout(resolve.bind(null, arr), 25)),
+            iterateeDelayWithOrder(order, (x) => x == 2)
+        );
+
+        return Promise.all([
+            p.should.eventually.deep.equal([2]),
+            p.then(() => arr.should.deep.equal([3, 2, 1])),
+            new Promise(resolve => setTimeout(
+                () => resolve(order.should.deep.equal([1, 2, 3])),
+                5 * 25
+            ))
+        ]);
+    });
+
     it('supports not found', function() {
         const p = async.filter([1, 2, 3], () => false);
 
@@ -170,10 +188,10 @@ describe('filter', function() {
         arr.shift();
 
         return Promise.all([
-            p.should.eventually.deep.equal([2, 1]),
+            p.should.eventually.deep.equal([2]),
             p.then(() => arr.should.deep.equal([3, 2])),
             new Promise(resolve => setTimeout(
-                () => resolve(order.should.deep.equal([4, 1, 2, 3])),
+                () => resolve(order.should.deep.equal([2, 3])),
                 5 * 25
             ))
         ]);

--- a/test/filterLimit.js
+++ b/test/filterLimit.js
@@ -130,6 +130,25 @@ describe('filterLimit', function() {
         });
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const arr = [3, 2, 1];
+        const p = async.filterLimit(
+            new Promise(resolve => setTimeout(resolve.bind(null, arr), 25)),
+            2,
+            iterateeDelayWithOrder(order, (x) => x == 2)
+        );
+
+        return Promise.all([
+            p.should.eventually.deep.equal([2]),
+            p.then(() => arr.should.deep.equal([3, 2, 1])),
+            new Promise(resolve => setTimeout(
+                () => resolve(order.should.deep.equal([2, 3, 1])),
+                5 * 25
+            ))
+        ]);
+    });
+
     it('supports not found', function() {
         const p = async.filterLimit([1, 2, 3], 2, () => false);
 
@@ -198,10 +217,10 @@ describe('filterLimit', function() {
         arr.shift();
 
         return Promise.all([
-            p.should.eventually.deep.equal([2, 1]),
+            p.should.eventually.deep.equal([2]),
             p.then(() => arr.should.deep.equal([3, 2])),
             new Promise(resolve => setTimeout(
-                () => resolve(order.should.deep.equal([4, 2, 1, 3])),
+                () => resolve(order.should.deep.equal([2, 3])),
                 5 * 25
             ))
         ]);

--- a/test/filterSeries.js
+++ b/test/filterSeries.js
@@ -130,6 +130,24 @@ describe('filterSeries', function() {
         });
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const arr = [3, 2, 1];
+        const p = async.filterSeries(
+            new Promise(resolve => setTimeout(resolve.bind(null, arr), 25)),
+            iterateeDelayWithOrder(order, (x) => x == 2)
+        );
+
+        return Promise.all([
+            p.should.eventually.deep.equal([2]),
+            p.then(() => arr.should.deep.equal([3, 2, 1])),
+            new Promise(resolve => setTimeout(
+                () => resolve(order.should.deep.equal(arr)),
+                8 * 25
+            ))
+        ]);
+    });
+
     it('supports not found', function() {
         const p = async.filterSeries([1, 2, 3], () => false);
 
@@ -170,10 +188,10 @@ describe('filterSeries', function() {
         arr.shift();
 
         return Promise.all([
-            p.should.eventually.deep.equal([2, 1]),
+            p.should.eventually.deep.equal([2]),
             p.then(() => arr.should.deep.equal([3, 2])),
             new Promise(resolve => setTimeout(
-                () => resolve(order.should.deep.equal([4, 3, 2, 1])),
+                () => resolve(order.should.deep.equal([3, 2])),
                 11 * 25
             ))
         ]);

--- a/test/filterSeries.js
+++ b/test/filterSeries.js
@@ -31,7 +31,7 @@ describe('filterSeries', function() {
             p.then(() => arr.should.deep.equal([3, 2, 1])),
             new Promise(resolve => setTimeout(
                 () => resolve(order.should.deep.equal(arr)),
-                7 * 25
+                8 * 25
             ))
         ]);
     });

--- a/test/forever.js
+++ b/test/forever.js
@@ -70,4 +70,31 @@ describe('forever', function() {
         ]);
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const p = async.forever(
+            new Promise(resolve => setTimeout(
+                resolve.bind(
+                    null,
+                    count => new Promise((resolve, reject) => setTimeout(_ => {
+                        order.push(`task${count}`);
+                        if (count == 25) {
+                            reject(new Error(count));
+                        } else {
+                            resolve(++count);
+                        }
+                    }, 25))
+                ),
+                25
+            )),
+            Promise.resolve(0)
+        );
+
+        return Promise.all([
+            p.should.eventually.be.rejectedWith(Error),
+            p.catch(() => order.should.deep.equal(
+                new Array(26).fill(null).map((_, index) => `task${index}`)
+            ))
+        ]);
+    });
 });

--- a/test/parallel.js
+++ b/test/parallel.js
@@ -76,6 +76,25 @@ describe('parallel', function() {
         ]);
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const arr = [1, 3, 2];
+        const tasks = arr.map(indexValue =>
+            delayedWithOrder(order, indexValue, (value, index) => {
+                value.should.equal(0);
+                return index;
+            })
+        );
+        const p = async.parallel(
+            new Promise(resolve => setTimeout(resolve.bind(null, tasks), 25)),
+            Promise.resolve(0)
+        );
+        return Promise.all([
+            p.should.eventually.deep.equal(arr),
+            p.then(() => order.should.deep.equal([1, 2, 3]))
+        ]);
+    });
+
     it('supports empty tasks', function() {
         const p = async.parallel([], () => assert(false, 'iteratee should not be called'));
 
@@ -120,9 +139,9 @@ describe('parallel', function() {
         tasks.shift();
 
         return Promise.all([
-            p.should.eventually.deep.equal(arr),
+            p.should.eventually.deep.equal([3, 2]),
             p.then(() => tasks.should.have.length(2)),
-            p.then(() => order.should.deep.equal([4, 1, 2, 3]))
+            p.then(() => order.should.deep.equal([2, 3]))
         ]);
     });
 

--- a/test/parallelLimit.js
+++ b/test/parallelLimit.js
@@ -77,6 +77,26 @@ describe('parallelLimit', function() {
         ]);
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const arr = [3, 1, 2, 1, 2];
+        const tasks = arr.map(indexValue =>
+            delayedWithOrder(order, indexValue, (value, index) => {
+                value.should.equal(0);
+                return index;
+            })
+        );
+        const p = async.parallelLimit(
+            new Promise(resolve => setTimeout(resolve.bind(null, tasks), 25)),
+            Promise.resolve(2),
+            Promise.resolve(0)
+        );
+        return Promise.all([
+            p.should.eventually.deep.equal(arr),
+            p.then(() => order.should.deep.equal([1, 3, 2, 1, 2]))
+        ]);
+    });
+
     it('supports empty tasks', function() {
         const p = async.parallelLimit([], 2, () => assert(false, 'iteratee should not be called'));
 
@@ -155,9 +175,9 @@ describe('parallelLimit', function() {
         tasks.shift();
 
         return Promise.all([
-            p.should.eventually.deep.equal([4, 3, 2, 1]),
+            p.should.eventually.deep.equal([3, 2]),
             p.then(() => tasks.should.have.length(2)),
-            p.then(() => order.should.deep.equal([4, 2, 1, 3]))
+            p.then(() => order.should.deep.equal([2, 3]))
         ]);
     });
 

--- a/test/reduce.js
+++ b/test/reduce.js
@@ -89,6 +89,20 @@ describe('reduce', function() {
         });
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const arr = [1, 3, 2];
+        const p = async.reduce(
+            new Promise(resolve => setTimeout(resolve.bind(null, arr), 25)),
+            Promise.resolve(0),
+            accIterateeDelayWithOrder(order, (acc, x) => acc + x)
+        );
+        return Promise.all([
+            p.should.eventually.equal(6),
+            p.then(() => order.should.deep.equal(arr))
+        ]);
+    });
+
     it('supports empty collections', function() {
         const p = async.reduce([], 0, () => assert(false, 'iteratee should not be called'));
 
@@ -132,9 +146,9 @@ describe('reduce', function() {
         arr.shift();
 
         return Promise.all([
-            p.should.eventually.equal(10),
+            p.should.eventually.equal(5),
             p.then(() => arr.should.deep.equal([3, 2])),
-            p.then(() => order.should.deep.equal([4, 3, 2, 1]))
+            p.then(() => order.should.deep.equal([3, 2]))
         ]);
     });
 

--- a/test/reduceRight.js
+++ b/test/reduceRight.js
@@ -89,6 +89,21 @@ describe('reduceRight', function() {
         });
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const arr = [1, 3, 2];
+        const p = async.reduceRight(
+            new Promise(resolve => setTimeout(resolve.bind(null, arr), 25)),
+            Promise.resolve(0),
+            accIterateeDelayWithOrder(order, (acc, x) => acc + x)
+        );
+        return Promise.all([
+            p.should.eventually.equal(6),
+            p.then(() => order.should.deep.equal(arr.reverse()))
+        ]);
+    });
+
+
     it('supports empty collections', function() {
         const p = async.reduceRight([], 0, () => assert(false, 'iteratee should not be called'));
 
@@ -132,9 +147,9 @@ describe('reduceRight', function() {
         arr.shift();
 
         return Promise.all([
-            p.should.eventually.equal(10),
+            p.should.eventually.equal(5),
             p.then(() => arr.should.deep.equal([3, 2])),
-            p.then(() => order.should.deep.equal([1, 2, 3, 4]))
+            p.then(() => order.should.deep.equal([2, 3]))
         ]);
     });
 

--- a/test/reject.js
+++ b/test/reject.js
@@ -130,6 +130,24 @@ describe('reject', function() {
         });
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const arr = [3, 2, 1];
+        const p = async.reject(
+            new Promise(resolve => setTimeout(resolve.bind(null, arr), 25)),
+            iterateeDelayWithOrder(order, (x) => x == 2)
+        );
+
+        return Promise.all([
+            p.should.eventually.deep.equal([3, 1]),
+            p.then(() => arr.should.deep.equal([3, 2, 1])),
+            new Promise(resolve => setTimeout(
+                () => resolve(order.should.deep.equal([1, 2, 3])),
+                5 * 25
+            ))
+        ]);
+    });
+
     it('supports reject none', function() {
         const p = async.reject([1, 2, 3], () => false);
 
@@ -170,10 +188,10 @@ describe('reject', function() {
         arr.shift();
 
         return Promise.all([
-            p.should.eventually.deep.equal([4, 3, 2]),
+            p.should.eventually.deep.equal([3, 2]),
             p.then(() => arr.should.deep.equal([3, 2])),
             new Promise(resolve => setTimeout(
-                () => resolve(order.should.deep.equal([4, 1, 2, 3])),
+                () => resolve(order.should.deep.equal([2, 3])),
                 5 * 25
             ))
         ]);

--- a/test/rejectLimit.js
+++ b/test/rejectLimit.js
@@ -130,6 +130,25 @@ describe('rejectLimit', function() {
         });
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const arr = [3, 2, 1];
+        const p = async.rejectLimit(
+            new Promise(resolve => setTimeout(resolve.bind(null, arr), 25)),
+            2,
+            iterateeDelayWithOrder(order, (x) => x == 2)
+        );
+
+        return Promise.all([
+            p.should.eventually.deep.equal([3, 1]),
+            p.then(() => arr.should.deep.equal([3, 2, 1])),
+            new Promise(resolve => setTimeout(
+                () => resolve(order.should.deep.equal([2, 3, 1])),
+                5 * 25
+            ))
+        ]);
+    });
+
     it('supports not found', function() {
         const p = async.rejectLimit([1, 2, 3], 2, () => false);
 
@@ -198,10 +217,10 @@ describe('rejectLimit', function() {
         arr.shift();
 
         return Promise.all([
-            p.should.eventually.deep.equal([4, 3, 2]),
+            p.should.eventually.deep.equal([3, 2]),
             p.then(() => arr.should.deep.equal([3, 2])),
             new Promise(resolve => setTimeout(
-                () => resolve(order.should.deep.equal([4, 2, 1, 3])),
+                () => resolve(order.should.deep.equal([2, 3])),
                 5 * 25
             ))
         ]);

--- a/test/rejectSeries.js
+++ b/test/rejectSeries.js
@@ -130,6 +130,24 @@ describe('rejectSeries', function() {
         });
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const arr = [3, 2, 1];
+        const p = async.rejectSeries(
+            new Promise(resolve => setTimeout(resolve.bind(null, arr), 25)),
+            iterateeDelayWithOrder(order, (x) => x == 2)
+        );
+
+        return Promise.all([
+            p.should.eventually.deep.equal([3, 1]),
+            p.then(() => arr.should.deep.equal([3, 2, 1])),
+            new Promise(resolve => setTimeout(
+                () => resolve(order.should.deep.equal(arr)),
+                8 * 25
+            ))
+        ]);
+    });
+
     it('supports not found', function() {
         const p = async.rejectSeries([1, 2, 3], () => false);
 
@@ -170,10 +188,10 @@ describe('rejectSeries', function() {
         arr.shift();
 
         return Promise.all([
-            p.should.eventually.deep.equal([4, 3, 2]),
+            p.should.eventually.deep.equal([3, 2]),
             p.then(() => arr.should.deep.equal([3, 2])),
             new Promise(resolve => setTimeout(
-                () => resolve(order.should.deep.equal([4, 3, 2, 1])),
+                () => resolve(order.should.deep.equal([3, 2])),
                 11 * 25
             ))
         ]);

--- a/test/retry.js
+++ b/test/retry.js
@@ -160,15 +160,32 @@ describe('retry', function() {
         ]);
     });
 
-    it('throws with invalid times value', function(done) {
-        expect(async.retry.bind(null, 'foo', delayedTask(1, failTask)))
-            .to.throw(Error, `Invalid times option value of "foo"`)
-        done();
+    it('supports promised arguments', function() {
+        let order = [];
+        let counter = { count: 0 };
+        const p = async.retry(
+            Promise.resolve(delayedTask(1, successTask)),
+            new Promise(resolve => setTimeout(resolve.bind(null, order), 25)),
+            new Promise(resolve => setTimeout(resolve.bind(null, counter), 25))
+        );
+
+        return Promise.all([
+            p.should.eventually.deep.equal(3),
+            p.then(() => order.should.deep.equal([1, 2, 3]))
+        ]);
     });
 
-    it('throws with invalid times option', function(done) {
-        expect(async.retry.bind(null, { times: 'foo' }, delayedTask(1, failTask)))
-            .to.throw(Error, `Invalid times option value of "foo"`)
-        done();
+    it('rejects with invalid times value', function() {
+        const p = async.retry('foo', delayedTask(1, failTask));
+        return Promise.all([
+            p.should.eventually.be.rejectedWith(Error, `Invalid times option value of "foo"`)
+        ]);
+    });
+
+    it('rejects with invalid times option', function() {
+        const p = async.retry({ times: 'foo' }, delayedTask(1, failTask));
+        return Promise.all([
+            p.should.eventually.be.rejectedWith(Error, `Invalid times option value of "foo"`)
+        ]);
     });
 });

--- a/test/retryable.js
+++ b/test/retryable.js
@@ -170,16 +170,20 @@ describe('retryable', function() {
         ]);
     });
 
-    it('throws with invalid times value', function(done) {
-        expect(async.retryable('foo', delayedTask(1, failTask)))
-            .to.throw(Error, `Invalid times option value of "foo"`)
-        done();
+    it('rejects with invalid times value', function() {
+        const f = async.retryable('foo', delayedTask(1, failTask));
+        const p = f();
+        return Promise.all([
+            p.should.eventually.be.rejectedWith(Error, `Invalid times option value of "foo"`)
+        ]);
     });
 
-    it('throws with invalid times option', function(done) {
-        expect(async.retryable({ times: 'foo' }, delayedTask(1, failTask)))
-            .to.throw(Error, `Invalid times option value of "foo"`)
-        done();
+    it('throws with invalid times option', function() {
+        const f = async.retryable({ times: 'foo' }, delayedTask(1, failTask));
+        const p = f();
+        return Promise.all([
+            p.should.eventually.be.rejectedWith(Error, `Invalid times option value of "foo"`)
+        ]);
     });
 
 });

--- a/test/series.js
+++ b/test/series.js
@@ -30,6 +30,39 @@ describe('series', function() {
         ]);
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const tasks = [
+            (arg0, arg1) => new Promise(resolve => setTimeout(_ => {
+                order.push(1);
+                arg0.should.equal(0, 'assertion failed for series task arguments');
+                arg1.should.equal(1, 'assertion failed for series task arguments');
+                resolve(arg1)
+            }, 25)),
+            (arg0, arg1) => {
+                order.push(2);
+                arg0.should.equal(0, 'assertion failed for series task arguments');
+                arg1.should.equal(1, 'assertion failed for series task arguments');
+                return new Promise(resolve => resolve([1 + arg1, 2 + arg1]))
+            },
+            (arg0, arg1) => {
+                order.push(3);
+                arg0.should.equal(0, 'assertion failed for series task arguments');
+                arg1.should.equal(1, 'assertion failed for series task arguments');
+                return 1 + arg0 + arg1;
+            }
+        ];
+        const p = async.series(
+            new Promise(resolve => setTimeout(resolve.bind(null, tasks), 25)),
+            Promise.resolve(0),
+            Promise.resolve(1)
+        );
+        return Promise.all([
+            p.should.eventually.deep.equal([1, [2, 3], 2]),
+            p.then(() => order.should.deep.equal([1, 2, 3]))
+        ]);
+    });
+
     it('supports empty collections', function() {
         const p = async.series([]);
         return Promise.all([

--- a/test/some.js
+++ b/test/some.js
@@ -121,6 +121,23 @@ describe('some', function() {
         });
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const arr = [3, 2, 1];
+        const p = async.some(
+            new Promise(resolve => setTimeout(resolve.bind(null, arr), 25)),
+            iterateeDelayWithOrder(order, (x) => x == 3)
+        );
+
+        return Promise.all([
+            p.should.eventually.equal(true),
+            new Promise(resolve => setTimeout(
+                () => resolve(order.should.deep.equal([1, 2, 3])),
+                5 * 25
+            ))
+        ]);
+    });
+
     it('supports empty collections', function() {
         const p = async.some([], () => assert(false, 'iteratee should not be called'));
 
@@ -156,7 +173,7 @@ describe('some', function() {
             p.should.eventually.equal(true),
             p.then(() => arr.should.deep.equal([3, 2])),
             new Promise(resolve => setTimeout(
-                () => resolve(order.should.deep.equal([4, 1, 2, 3])),
+                () => resolve(order.should.deep.equal([2, 3])),
                 5 * 25
             ))
         ]);

--- a/test/someLimit.js
+++ b/test/someLimit.js
@@ -121,6 +121,24 @@ describe('someLimit', function() {
         });
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const arr = [3, 2, 1];
+        const p = async.someLimit(
+            new Promise(resolve => setTimeout(resolve.bind(null, arr), 25)),
+            2,
+            iterateeDelayWithOrder(order, (x) => x == 3)
+        );
+
+        return Promise.all([
+            p.should.eventually.equal(true),
+            new Promise(resolve => setTimeout(
+                () => resolve(order.should.deep.equal([2, 3, 1])),
+                5 * 25
+            ))
+        ]);
+    });
+
     it('supports empty collections', function() {
         const p = async.someLimit([], 2, () => assert(false, 'iteratee should not be called'));
 
@@ -184,7 +202,7 @@ describe('someLimit', function() {
             p.should.eventually.equal(true),
             p.then(() => arr.should.deep.equal([3, 2])),
             new Promise(resolve => setTimeout(
-                () => resolve(order.should.deep.equal([4, 2, 1, 3])),
+                () => resolve(order.should.deep.equal([2, 3])),
                 7 * 25
             ))
         ]);

--- a/test/someSeries.js
+++ b/test/someSeries.js
@@ -127,6 +127,23 @@ describe('someSeries', function() {
         });
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const arr = [3, 2, 1];
+        const p = async.someSeries(
+            new Promise(resolve => setTimeout(resolve.bind(null, arr), 25)),
+            iterateeDelayWithOrder(order, (x) => x == 1)
+        );
+
+        return Promise.all([
+            p.should.eventually.equal(true),
+            new Promise(resolve => setTimeout(
+                () => resolve(order.should.deep.equal(arr)),
+                8 * 25
+            ))
+        ]);
+    });
+
     it('supports empty collections', function() {
         const p = async.someSeries([], () => assert(false, 'iteratee should not be called'));
 
@@ -144,14 +161,14 @@ describe('someSeries', function() {
                     setTimeout(
                         () => {
                             order.push(value);
-                            resolve(value < 2);
+                            resolve(value < 3);
                         },
                         value * 25
                     );
                 });
             } else {
                 order.push(value);
-                return Promise.resolve(value < 2);
+                return Promise.resolve(value < 3);
             }
         });
 
@@ -162,7 +179,7 @@ describe('someSeries', function() {
             p.should.eventually.equal(true),
             p.then(() => arr.should.deep.equal([3, 2])),
             new Promise(resolve => setTimeout(
-                () => resolve(order.should.deep.equal([4, 3, 2, 1])),
+                () => resolve(order.should.deep.equal([3, 2])),
                 11 * 25
             ))
         ]);

--- a/test/sortBy.js
+++ b/test/sortBy.js
@@ -96,6 +96,19 @@ describe('sortBy', function() {
         });
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const arr = [1, 3, 2];
+        const p = async.sortBy(
+            new Promise(resolve => setTimeout(resolve.bind(null, arr), 25)),
+            iterateeDelayWithOrder(order)
+        );
+        return Promise.all([
+            p.should.eventually.deep.equal([1, 2, 3]),
+            p.then(() => order.should.deep.equal([1, 2, 3]))
+        ]);
+    });
+
     it('supports empty collections', function() {
         const p = async.sortBy([], () => assert(false, 'iteratee should not be called'));
 
@@ -139,9 +152,9 @@ describe('sortBy', function() {
         arr.shift();
 
         return Promise.all([
-            p.should.eventually.deep.equal([1, 2, 3, 4]),
+            p.should.eventually.deep.equal([2, 3]),
             p.then(() => arr.should.deep.equal([3, 2])),
-            p.then(() => order.should.deep.equal([4, 1, 2, 3]))
+            p.then(() => order.should.deep.equal([2, 3]))
         ]);
     });
 

--- a/test/times.js
+++ b/test/times.js
@@ -53,6 +53,23 @@ describe('times', function() {
         ]);
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const p = async.times(
+            Promise.resolve(5),
+            Promise.resolve((index, order) => new Promise(resolve => setTimeout(_ => {
+                order.push(index);
+                resolve(index);
+            }, (5 - index) * 25))),
+            new Promise(resolve => setTimeout(resolve.bind(null, order), 25))
+        );
+
+        return Promise.all([
+            p.should.eventually.deep.equal([0, 1, 2, 3, 4]),
+            p.then(() => order.should.deep.equal([4, 3, 2, 1, 0]))
+        ]);
+    });
+
     it('rejects on 3rd delayed iteration', function() {
         let order = [];
         const p = async.times(5, delayedTask(1, failTask), order);

--- a/test/timesLimit.js
+++ b/test/timesLimit.js
@@ -46,6 +46,21 @@ describe('timesLimit', function() {
         ]);
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const p = async.timesLimit(
+            Promise.resolve(5),
+            2,
+            Promise.resolve(delayedTask(1, successTask)),
+            new Promise(resolve => setTimeout(resolve.bind(null, order), 25))
+        );
+
+        return Promise.all([
+            p.should.eventually.deep.equal([0, 1, 2, 3, 4]),
+            p.then(() => order.should.deep.equal([0, 1, 2, 3, 4]))
+        ]);
+    });
+
     it('rejects on 3rd delayed iteration', function() {
         let order = [];
         const p = async.timesLimit(5, 2, delayedTask(1, failTask), order);

--- a/test/timesSeries.js
+++ b/test/timesSeries.js
@@ -53,6 +53,23 @@ describe('timesSeries', function() {
         ]);
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const p = async.timesSeries(
+            Promise.resolve(5),
+            Promise.resolve((index, order) => new Promise(resolve => setTimeout(_ => {
+                order.push(index);
+                resolve(index);
+            }, (5 - index) * 25))),
+            new Promise(resolve => setTimeout(resolve.bind(null, order), 25))
+        );
+
+        return Promise.all([
+            p.should.eventually.deep.equal([0, 1, 2, 3, 4]),
+            p.then(() => order.should.deep.equal([0, 1, 2, 3, 4]))
+        ]);
+    });
+
     it('rejects on 3rd delayed iteration', function() {
         let order = [];
         const p = async.timesSeries(5, delayedTask(1, failTask), order);

--- a/test/transform.js
+++ b/test/transform.js
@@ -110,6 +110,19 @@ describe('transform', function() {
         });
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const arr = [1, 3, 2];
+        const p = async.transform(
+            new Promise(resolve => setTimeout(resolve.bind(null, arr), 25)),
+            accIterateeDelayWithOrder(order, (acc, x) => acc.push(x + 1))
+        );
+        return Promise.all([
+            p.should.eventually.deep.equal([2, 4, 3]),
+            p.then(() => order.should.deep.equal(arr))
+        ]);
+    });
+
     it('supports empty collections', function() {
         const p = async.transform([], () => assert(false, 'iteratee should not be called'));
 
@@ -166,9 +179,9 @@ describe('transform', function() {
         arr.shift();
 
         return Promise.all([
-            p.should.eventually.deep.equal([5, 4, 3, 2]),
+            p.should.eventually.deep.equal([4, 3]),
             p.then(() => arr.should.deep.equal([3, 2])),
-            p.then(() => order.should.deep.equal([4, 3, 2, 1]))
+            p.then(() => order.should.deep.equal([3, 2]))
         ]);
     });
 

--- a/test/until.js
+++ b/test/until.js
@@ -142,6 +142,52 @@ describe('until', function() {
         ]);
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const p = async.until(
+            new Promise(resolve => setTimeout(
+                resolve.bind(
+                    null,
+                    count => new Promise(resolve => setTimeout(_ => {
+                        order.push(`condition${count}`);
+                        resolve(count == 5);
+                    }, 25))
+                ),
+                25
+            )),
+            new Promise(resolve => setTimeout(
+                resolve.bind(
+                    null,
+                    count => new Promise(resolve => setTimeout(_ => {
+                        order.push(`task${count}`);
+                        count++;
+                        resolve(count);
+                    }, 25))
+                ),
+                25
+            )),
+            Promise.resolve(0)
+        );
+
+        return Promise.all([
+            p.should.eventually.equal(undefined),
+            p.then(() => order.should.deep.equal([
+                'condition0',
+                'task0',
+                'condition1',
+                'task1',
+                'condition2',
+                'task2',
+                'condition3',
+                'task3',
+                'condition4',
+                'task4',
+                'condition5'
+            ]))
+        ]);
+    });
+
+
     it('rejects in delayed task', function() {
         let order = [];
         const p = async.until(

--- a/test/whilst.js
+++ b/test/whilst.js
@@ -106,6 +106,53 @@ describe('whilst', function() {
         ]);
     });
 
+    it('supports promised arguments', function() {
+        let order = [];
+        const p = async.whilst(
+            new Promise(resolve => setTimeout(
+                resolve.bind(
+                    null,
+                    count => new Promise(resolve => setTimeout(_ => {
+                        order.push(`condition${count}`);
+                        resolve(count < 5);
+                    }, 25))
+                ),
+                25
+            )),
+
+            new Promise(resolve => setTimeout(
+                resolve.bind(
+                    null,
+                    count => new Promise(resolve => setTimeout(_ => {
+                        order.push(`task${count}`);
+                        count++;
+                        resolve(count);
+                    }, 25))
+                ),
+                25
+            )),
+
+            Promise.resolve(0)
+        );
+
+        return Promise.all([
+            p.should.eventually.equal(undefined),
+            p.then(() => order.should.deep.equal([
+                'condition0',
+                'task0',
+                'condition1',
+                'task1',
+                'condition2',
+                'task2',
+                'condition3',
+                'task3',
+                'condition4',
+                'task4',
+                'condition5'
+            ]))
+        ]);
+    });
+
     it('rejects in delayed task', function() {
         let order = [];
         const p = async.whilst(


### PR DESCRIPTION
For collection and control flow methods that return a Promise, they can now accept a Promise for each argument.

This is the PR for issue #4.
